### PR TITLE
Avoid overriding keybinding in example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can read more about the concept of harpoon on the GitHub of the original imp
   ;; Example bindings
   :bind (:map harpoon-minor-mode-map
 	      ("C-c h m" . 'harpoon-set)
-	      ("C-c h l" . 'harpoon-buffer)
+	      ("C-c h b" . 'harpoon-buffer)
 	      ("C-c h h" . 'harpoon-jump-1)
 	      ("C-c h j" . 'harpoon-jump-2)
 	      ("C-c h k" . 'harpoon-jump-3)


### PR DESCRIPTION
Hi! Thanks for creating this package, really liking it so far. Just wanted to point that the `harpoon-buffer` keybinding present in the example configuration later gets overridden by the `harpoon-jump-4` keybinding, this PR fixes it.

Thanks once again ^^